### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress">
-    <!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-    <!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+    <!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+    <!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
     <!-- Set a description for this ruleset. -->
     <description>A custom set of code standard rules to check for WordPress themes.</description>
 
     <!-- Exclude folders. -->
-    <!-- See: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+    <!-- See: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>*/build/*</exclude-pattern>

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ about git workflow with this project template.
 * Git hooks to test your code to make sure that only high quality code is
   committed into git
 * Advanced WordPress acceptance tests with Codeception and headless Chrome
-* [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer) code style
+* [PHP Codesniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) code style
   and quality analyzer
 * Includes self-signed certs (and trust them automatically in OS X) to test
   https:// locally

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -152,7 +152,7 @@
 
   <!--
     Add some custom sniff rules in this section below. See
-    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties and
+    https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties and
     https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
     for available sniffs and their properties.
   -->


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932