### PR TITLE
Add current year as block binding

### DIFF
--- a/htdocs/wp-content/plugins/mt-features/includes/class-register-bindings.php
+++ b/htdocs/wp-content/plugins/mt-features/includes/class-register-bindings.php
@@ -31,6 +31,14 @@ class Register_Bindings {
 				'get_value_callback' => array( $this, 'mt_bindings_callback' ),
 			)
 		);
+
+		\register_block_bindings_source(
+			'mt-features/current-year',
+			array(
+				'label'              => __( 'Current Year', 'mt-features' ),
+				'get_value_callback' => array( $this, 'mt_bindings_current_year_callback' ),
+			)
+		);
 	}
 
 	/**
@@ -81,6 +89,15 @@ class Register_Bindings {
 			default:
 				return null;
 		}
+	}
+
+	/**
+	 * Bindings callback for current year.
+	 *
+	 * @return string The current year.
+	 */
+	public function mt_bindings_current_year_callback() {
+		return gmdate( 'Y' );
 	}
 }
 

--- a/htdocs/wp-content/plugins/mt-features/src/index.js
+++ b/htdocs/wp-content/plugins/mt-features/src/index.js
@@ -42,6 +42,23 @@ registerBlockBindingsSource( {
     },
 } );
 
+// Register a current year field binding source to the editor UI.
+registerBlockBindingsSource( {
+    name: 'mt-features/current-year',
+    label: __( 'Current year', 'mt-features' ),
+    getFieldsList() {
+        return [
+			{
+				label: __( 'Current year', 'mt-features' ),
+				type: 'string',
+				args: {
+					key: 'current_year',
+				},
+			},
+        ];
+    },
+} );
+
 /**
  * Register a SlotFill to the custom UI to the document settings panel.
  */


### PR DESCRIPTION
This is useful for example in the footer so that we don't have to manually change the year.

Impact: minor
Related: GMF-57